### PR TITLE
Add IUnitOfWork interface and UnitOfWork implementation

### DIFF
--- a/Redde/Application/Interfaces/IUnitOfWork.cs
+++ b/Redde/Application/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,13 @@
+﻿using Redde.Domain.Entities;
+
+namespace Redde.Application.Interfaces
+{
+    public interface IUnitOfWork : IDisposable
+    {
+        IRepository<User> Users { get; }
+        IRepository<Company> Companies { get; }
+        IRepository<Role> Roles { get; }
+
+        Task<int> SaveChangesAsync();
+    }
+}

--- a/Redde/Infrastructure/Persistence/UnitOfWork.cs
+++ b/Redde/Infrastructure/Persistence/UnitOfWork.cs
@@ -1,0 +1,37 @@
+﻿using Redde.Application.Interfaces;
+using Redde.Domain.Entities;
+using Redde.Infraestructure.Persistence;
+using Redde.Infrastructure.Repositories;
+
+namespace Redde.Infrastructure.Persistence
+{
+    public class UnitOfWork : IUnitOfWork
+    {
+        private readonly ApplicationDbContext _context;
+
+        public IRepository<User> Users { get; private set; }
+        public IRepository<Company> Companies { get; private set; }
+        public IRepository<Role> Roles { get; private set; }
+
+
+        public UnitOfWork(ApplicationDbContext context)
+        {
+            _context = context;
+
+            Users = new Repository<User>(_context);
+            Companies = new Repository<Company>(_context);
+            Roles = new Repository<Role>(_context);
+        }
+
+        public async Task<int> SaveChangesAsync()
+        {
+            return await _context.SaveChangesAsync();
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+    }
+}


### PR DESCRIPTION
Introduces the `IUnitOfWork` interface to define a unit of work pattern with repository properties for `User`, `Company`, and `Role` entities. Implements the `UnitOfWork` class, which initializes these repositories and provides methods for saving changes asynchronously and disposing of resources.