### PR TITLE
Add DatabaseSeeder for initial data seeding

### DIFF
--- a/Redde/Infrastructure/Seeders/DatabaseSeeder.cs
+++ b/Redde/Infrastructure/Seeders/DatabaseSeeder.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Redde.Domain.Entities;
+using Redde.Infraestructure.Persistence;
+using Redde.Infrastructure.Persistence;
+
+public static class DatabaseSeeder
+{
+    public static async Task SeedAsync(ApplicationDbContext context)
+    {
+        await context.Database.MigrateAsync();
+
+        if (!await context.Roles.AnyAsync())
+        {
+            await context.Roles.AddRangeAsync(
+                new Role { Name = "Admin" },
+                new Role { Name = "Owner" },
+                new Role { Name = "Empleado" }
+            );
+            await context.SaveChangesAsync();
+        }
+
+        if (!await context.Users.AnyAsync(u => u.Email == "admin@redde.com"))
+        {
+            var adminRole = await context.Roles.FirstAsync(r => r.Name == "Admin");
+
+            var admin = new User
+            {
+                Name = "Super Admin",
+                Email = "admin@redde.com",
+                Password = BCrypt.Net.BCrypt.HashPassword("Admin123!"),
+                RoleId = adminRole.Id,
+                Provider = "local"
+            };
+
+            await context.Users.AddAsync(admin);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Redde/Program.cs
+++ b/Redde/Program.cs
@@ -129,6 +129,7 @@ using (var scope = app.Services.CreateScope())
 {
     var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     await DbSeeder.SeedRolesAsync(dbContext);
+    await DatabaseSeeder.SeedAsync(dbContext);
 }
 
 app.Run();


### PR DESCRIPTION
Updated Program.cs to call DatabaseSeeder.SeedAsync during startup. Introduced DatabaseSeeder class to handle database migrations and seed roles and an admin user if they do not exist.