### PR TITLE
Refactor company response and add new services/controllers

### DIFF
--- a/Redde/Application/DTOs/Company/CatalogResponse.cs
+++ b/Redde/Application/DTOs/Company/CatalogResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Redde.Application.DTOs.Company
+{
+    public class CatalogResponse
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+    }
+}

--- a/Redde/Application/DTOs/Company/CompanyResponse.cs
+++ b/Redde/Application/DTOs/Company/CompanyResponse.cs
@@ -7,9 +7,9 @@ public class CompanyResponse
     public string Name { get; set; } = null!;
     public string CommercialName { get; set; } = null!;
 
-    public string Category { get; set; } = null!;
-    public string PaymentScheme { get; set; } = null!;
-    public string State { get; set; } = null!;
-    public string EconomicActivity { get; set; } = null!;
-    public string GovernmentBranch { get; set; } = null!;
+    public CatalogResponse Category { get; set; } = null!;
+    public CatalogResponse PaymentScheme { get; set; } = null!;
+    public CatalogResponse State { get; set; } = null!;
+    public CatalogResponse EconomicActivity { get; set; } = null!;
+    public CatalogResponse GovernmentBranch { get; set; } = null!;
 }

--- a/Redde/Application/DTOs/DropDownOptions/DropDownOptionsDTO.cs
+++ b/Redde/Application/DTOs/DropDownOptions/DropDownOptionsDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace Redde.Application.DTOs.DropDownOptions
+{
+    public class DropDownOptionsDTO
+    {
+        public int Id { get; set; }
+        public required string Name { get; set; }
+    }
+}

--- a/Redde/Application/Services/CompanyService.cs
+++ b/Redde/Application/Services/CompanyService.cs
@@ -51,11 +51,11 @@ public class CompanyService(IUnitOfWork unitOfWork) : ICompanyService
             RNC = c.RNC,
             Name = c.Name,
             CommercialName = c.CommercialName,
-            Category = c.Category.Name,
-            PaymentScheme = c.PaymentScheme.Name,
-            State = c.State.Name,
-            EconomicActivity = c.EconomicActivity.Name,
-            GovernmentBranch = c.GovernmentBranch.Name
+            Category = new CatalogResponse { Id = c.Category.Id, Name = c.Category.Name },
+            PaymentScheme = new CatalogResponse { Id = c.PaymentScheme.Id, Name = c.PaymentScheme.Name },
+            State = new CatalogResponse { Id = c.State.Id, Name = c.State.Name },
+            EconomicActivity = new CatalogResponse { Id = c.EconomicActivity.Id, Name = c.EconomicActivity.Name },
+            GovernmentBranch = new CatalogResponse { Id = c.GovernmentBranch.Id, Name = c.GovernmentBranch.Name }
         });
     }
 
@@ -77,11 +77,11 @@ public class CompanyService(IUnitOfWork unitOfWork) : ICompanyService
             RNC = company.RNC,
             Name = company.Name,
             CommercialName = company.CommercialName,
-            Category = company.Category.Name,
-            PaymentScheme = company.PaymentScheme.Name,
-            State = company.State.Name,
-            EconomicActivity = company.EconomicActivity.Name,
-            GovernmentBranch = company.GovernmentBranch.Name
+            Category = new CatalogResponse { Id = company.Category.Id, Name = company.Category.Name },
+            PaymentScheme = new CatalogResponse { Id = company.PaymentScheme.Id, Name = company.PaymentScheme.Name },
+            State = new CatalogResponse { Id = company.State.Id, Name = company.State.Name },
+            EconomicActivity = new CatalogResponse { Id = company.EconomicActivity.Id, Name = company.EconomicActivity.Name },
+            GovernmentBranch = new CatalogResponse { Id = company.GovernmentBranch.Id, Name = company.GovernmentBranch.Name }
         };
     }
 

--- a/Redde/Application/Services/DgiiService.cs
+++ b/Redde/Application/Services/DgiiService.cs
@@ -1,0 +1,75 @@
+﻿using System.Net.Http.Headers;
+using HtmlAgilityPack;
+
+public class DgiiService
+{
+    private readonly HttpClient _http;
+
+    public DgiiService(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<DgiiResponse> ConsultarRNC(string rnc)
+    {
+        var baseUrl = "https://dgii.gov.do/app/WebApps/ConsultasWeb2/ConsultasWeb/consultas/rnc.aspx";
+
+        var initialResponse = await _http.GetAsync(baseUrl);
+        var html = await initialResponse.Content.ReadAsStringAsync();
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        string viewState = doc.DocumentNode
+            .SelectSingleNode("//input[@id='__VIEWSTATE']")
+            ?.GetAttributeValue("value", "") ?? "";
+
+        string eventValidation = doc.DocumentNode
+            .SelectSingleNode("//input[@id='__EVENTVALIDATION']")
+            ?.GetAttributeValue("value", "") ?? "";
+
+        var form = new Dictionary<string, string>
+        {
+            ["__VIEWSTATE"] = viewState,
+            ["__EVENTVALIDATION"] = eventValidation,
+            ["ctl00$ctl00$ctl00$MainContent$MainContent$txtRncCedula"] = rnc,
+            ["ctl00$ctl00$ctl00$MainContent$MainContent$btnBuscarPorRNC"] = "Buscar"
+        };
+
+        var postContent = new FormUrlEncodedContent(form);
+
+        var postResponse = await _http.PostAsync(baseUrl, postContent);
+        var resultHtml = await postResponse.Content.ReadAsStringAsync();
+
+        var resultDoc = new HtmlDocument();
+        resultDoc.LoadHtml(resultHtml);
+
+        string nombre = resultDoc.DocumentNode
+            .SelectSingleNode("//span[@id='MainContent_MainContent_lblNombre']")
+            ?.InnerText.Trim() ?? "";
+
+        string estado = resultDoc.DocumentNode
+            .SelectSingleNode("//span[@id='MainContent_MainContent_lblEstado']")
+            ?.InnerText.Trim() ?? "";
+
+        string tipo = resultDoc.DocumentNode
+            .SelectSingleNode("//span[@id='MainContent_MainContent_lblTipo']")
+            ?.InnerText.Trim() ?? "";
+
+        return new DgiiResponse
+        {
+            Rnc = rnc,
+            Nombre = nombre,
+            Estado = estado,
+            Tipo = tipo
+        };
+    }
+}
+
+public class DgiiResponse
+{
+    public string Rnc { get; set; } = "";
+    public string Nombre { get; set; } = "";
+    public string Estado { get; set; } = "";
+    public string Tipo { get; set; } = "";
+}

--- a/Redde/Controllers/DgiiController.cs
+++ b/Redde/Controllers/DgiiController.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DgiiController : ControllerBase
+{
+    private readonly DgiiService _dgiiService;
+
+    public DgiiController(DgiiService dgiiService)
+    {
+        _dgiiService = dgiiService;
+    }
+
+    [HttpGet("{rnc}")]
+    public async Task<IActionResult> Get(string rnc)
+    {
+        var result = await _dgiiService.ConsultarRNC(rnc);
+        return Ok(result);
+    }
+}

--- a/Redde/Controllers/DropDownOptionsController.cs
+++ b/Redde/Controllers/DropDownOptionsController.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Redde.Application.DTOs.DropDownOptions;
+using Redde.Infraestructure.Persistence;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DropDownOptionsController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+
+    public DropDownOptionsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet("company-categories")]
+    public async Task<ActionResult<IEnumerable<DropDownOptionsDTO>>> GetCompanyCategories()
+    {
+        return await _context.CompanyCategories
+            .Select(c => new DropDownOptionsDTO { Id = c.Id, Name = c.Name })
+            .ToListAsync();
+    }
+
+    [HttpGet("payment-schemes")]
+    public async Task<ActionResult<IEnumerable<DropDownOptionsDTO>>> GetPaymentSchemes()
+    {
+        return await _context.PaymentSchemes
+            .Select(p => new DropDownOptionsDTO { Id = p.Id, Name = p.Name })
+            .ToListAsync();
+    }
+
+    [HttpGet("company-states")]
+    public async Task<ActionResult<IEnumerable<DropDownOptionsDTO>>> GetCompanyStates()
+    {
+        return await _context.CompanyStates
+            .Select(s => new DropDownOptionsDTO { Id = s.Id, Name = s.Name })
+            .ToListAsync();
+    }
+
+    [HttpGet("economic-activities")]
+    public async Task<ActionResult<IEnumerable<DropDownOptionsDTO>>> GetEconomicActivities()
+    {
+        return await _context.EconomicActivities
+            .Select(e => new DropDownOptionsDTO { Id = e.Id, Name = e.Name })
+            .ToListAsync();
+    }
+
+    [HttpGet("government-branches")]
+    public async Task<ActionResult<IEnumerable<DropDownOptionsDTO>>> GetGovernmentBranches()
+    {
+        return await _context.GovernmentBranches
+            .Select(g => new DropDownOptionsDTO { Id = g.Id, Name = g.Name })
+            .ToListAsync();
+    }
+}

--- a/Redde/Controllers/UserController.cs
+++ b/Redde/Controllers/UserController.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Redde.Application.Interfaces;
+
+namespace Redde.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Roles = "Admin")]
+public class UserController(IUserService userService) : ControllerBase
+{
+    private readonly IUserService _userService = userService;
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var users = await _userService.GetAllUsersAsync();
+        return Ok(users);
+    }
+}

--- a/Redde/Program.cs
+++ b/Redde/Program.cs
@@ -111,6 +111,8 @@ builder.Services.AddAuthorizationBuilder()
     .AddPolicy("IsOwnerOfCompany", policy =>
         policy.Requirements.Add(new IsOwnerOfCompanyRequirement()));
 
+builder.Services.AddHttpClient<DgiiService>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/Redde/Redde.csproj
+++ b/Redde/Redde.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">


### PR DESCRIPTION
- Updated `CompanyResponse` to use `CatalogResponse` for properties like `Category`, `PaymentScheme`, `State`, `EconomicActivity`, and `GovernmentBranch`.

- Modified mappings in `CompanyService` to create instances of `CatalogResponse`.

- Registered `DgiiService` HTTP client in `Program.cs`.

- Added `HtmlAgilityPack` package reference in `Redde.csproj`.

- Introduced new `CatalogResponse` and `DropDownOptionsDTO` classes.

- Implemented `DgiiService` for RNC consultations and parsing HTML responses.

- Created `DgiiController` for RNC-related API endpoints.

- Added `DropDownOptionsController` for various dropdown options from the database.

- Updated `UserController` to enforce "Admin" role authorization and retrieve all users.